### PR TITLE
Update MongoDB image tag to latest

### DIFF
--- a/kubernetes/mongodb/values.yaml
+++ b/kubernetes/mongodb/values.yaml
@@ -105,7 +105,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mongodb
-  tag: 4.4.15-debian-10-r8
+  tag: latest
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
this version doesn't exist.  here is the error
```
level=WARN msg="unable to find exact version; falling back to closest available version" chart=mongodb requested="" selected=18.1.10
Error: INSTALLATION FAILED: execution error at (mongodb/templates/NOTES.txt:176:4):

⚠ ERROR: Original containers have been substituted for unrecognized ones. Deploying this chart with non-standard containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.

Unrecognized images:
  - docker.io/bitnami/bitnami-shell:11-debian-11-r13

If you are sure you want to proceed with non-standard containers, you can skip container image verification by setting the global parameter 'global.security.allowInsecureImages' to true.
Further information can be obtained at https://github.com/bitnami/charts/issues/30850
```